### PR TITLE
Fix a problem with the dropdown list 'Tab Text' in the plugin settings

### DIFF
--- a/app/views/settings/_redminetab_settings.html.erb
+++ b/app/views/settings/_redminetab_settings.html.erb
@@ -1,4 +1,5 @@
 <% string_fields = ProjectCustomField.find :all %>
+<% select_options = '<option value="">(Select one)</option>' << options_from_collection_for_select(string_fields, :id, :name, @settings['tab_text'].to_i) %>
 
 <fieldset>
 <legend><%= l(:tab_text_project_specific) %></legend>
@@ -7,9 +8,7 @@
 </p>
 
 <p><label><%= l(:tab_label_tab_text) %></label>
-<%= select_tag 'settings[tab_text]',
-               '<option value="">(Select one)</option>' +
-               options_from_collection_for_select(string_fields, :id, :name, @settings['tab_text'].to_i) %><br />
+<%= select_tag 'settings[tab_text]', select_options.html_safe %><br />
 </p>
 </fieldset>
 


### PR DESCRIPTION
This is a little fix around the 'tab Text' drop down list.
Basically, the drop down list was always empty. I didn't even have the 'Select one' option.
Looking at the examples on the following page, it seems that it is a good idea to use html_safe:
http://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-select_tag
And it appeared that it fixed the problem.

I am using:
Redmine 2.1.4.stable
Ruby 1.8.7 (x86_64-linux)
Rails 3.2.8
