### PR TITLE
Fix top_menu link. 

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 RedmineApp::Application.routes.draw do  
   match 'tab/show', :to => 'tab#show'
-  match 'tab/show', :to => 'tab#system_show'
+  match 'tab/system_show', :to => 'tab#system_show'
 end


### PR DESCRIPTION
In 'tab/show', the link of the top menu of redmine became an error. 
Therefore, 'tab/show' was changed into 'tab/show'. 
